### PR TITLE
feat: generate egress tracker proof

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -110,26 +110,29 @@ func (c *Client) IsRegistered(ctx context.Context, req *IsRegisteredRequest) (bo
 		}
 		return false, fmt.Errorf("check registration failed with status: %d", resp.StatusCode)
 	}
-
-	return true, nil
 }
 
-type RequestProofRequest struct {
+type RequestProofsRequest struct {
 	DID string `json:"did"`
 }
 
-type RequestProofResponse struct {
-	Proof string `json:"proof"`
+type RequestProofsResponse struct {
+	Proofs Proofs `json:"proofs"`
 }
 
-func (c *Client) RequestProof(ctx context.Context, did string) (*RequestProofResponse, error) {
-	req := &RequestProofRequest{DID: did}
+type Proofs struct {
+	Indexer       string `json:"indexer"`
+	EgressTracker string `json:"egress_tracker"`
+}
+
+func (c *Client) RequestProofs(ctx context.Context, did string) (*RequestProofsResponse, error) {
+	req := &RequestProofsRequest{DID: did}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/registrar/request-proof", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/registrar/request-proofs", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -151,7 +154,7 @@ func (c *Client) RequestProof(ctx context.Context, did string) (*RequestProofRes
 		return nil, fmt.Errorf("request proof failed with status: %d", resp.StatusCode)
 	}
 
-	var result RequestProofResponse
+	var result RequestProofsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,6 +32,8 @@ var ServeCmd = &cobra.Command{
 				providers.ProvideSigner,
 				providers.ProvideIndexingServiceWebDID,
 				providers.ProvideIndexingServiceProof,
+				providers.ProvideEgressTrackingServiceDID,
+				providers.ProvideEgressTrackingServiceProof,
 				providers.ProvideUploadServiceDID,
 
 				// Store
@@ -73,6 +75,8 @@ func init() {
 	ServeCmd.Flags().String("delegator-key-file", "", "Path to delegator private key file")
 	ServeCmd.Flags().String("delegator-indexing-service-did", "", "DID of the indexing service")
 	ServeCmd.Flags().String("delegator-indexing-service-proof", "", "Path to proof file from indexing service")
+	ServeCmd.Flags().String("delegator-egress-tracking-service-did", "", "DID of the egress tracking service")
+	ServeCmd.Flags().String("delegator-egress-tracking-service-proof", "", "Path to proof file from egress tracking service")
 	ServeCmd.Flags().String("delegator-upload-service-did", "", "DID of the upload service")
 
 	// Bind flags to viper
@@ -88,5 +92,7 @@ func init() {
 	cobra.CheckErr(viper.BindPFlag("delegator.key_file", ServeCmd.Flags().Lookup("delegator-key-file")))
 	cobra.CheckErr(viper.BindPFlag("delegator.indexing_service_web_did", ServeCmd.Flags().Lookup("delegator-indexing-service-did")))
 	cobra.CheckErr(viper.BindPFlag("delegator.indexing_service_proof", ServeCmd.Flags().Lookup("delegator-indexing-service-proof")))
+	cobra.CheckErr(viper.BindPFlag("delegator.egress_tracking_service_did", ServeCmd.Flags().Lookup("delegator-egress-tracking-service-did")))
+	cobra.CheckErr(viper.BindPFlag("delegator.egress_tracking_service_proof", ServeCmd.Flags().Lookup("delegator-egress-tracking-service-proof")))
 	cobra.CheckErr(viper.BindPFlag("delegator.upload_service_did", ServeCmd.Flags().Lookup("delegator-upload-service-did")))
 }

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
-	github.com/storacha/go-libstoracha v0.2.0
-	github.com/storacha/go-ucanto v0.4.2
+	github.com/storacha/go-libstoracha v0.2.6
+	github.com/storacha/go-ucanto v0.5.0
 	go.uber.org/fx v1.23.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -582,10 +582,10 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
-github.com/storacha/go-libstoracha v0.2.0 h1:x3yz7PrTqVWT86hu/3OcKrS/72mLKfSdfIn8QoBw2rI=
-github.com/storacha/go-libstoracha v0.2.0/go.mod h1:68KXcak6CtWPKHlPV7emXbRbC+6LBiIWPbYrJ0urVf8=
-github.com/storacha/go-ucanto v0.4.2 h1:d9m9+a5W7U8VwIMqtGIwJOP3KZtEJOKNkQhveDczHEI=
-github.com/storacha/go-ucanto v0.4.2/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
+github.com/storacha/go-libstoracha v0.2.6 h1:UlRr6OqdiRFYf6WsvVEsWQvWOHj2zKvTdTeyDn7PK0g=
+github.com/storacha/go-libstoracha v0.2.6/go.mod h1:zzeqIZhBBuWR2dkGygYqv4Bhg3JsvHuuvDCcdXCwGhg=
+github.com/storacha/go-ucanto v0.5.0 h1:BCYfTOjJ7DxmoGwpZn4N1XITWj1BdKIbk5Ok7kMoQ6I=
+github.com/storacha/go-ucanto v0.5.0/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,12 @@ func NewConfig() (*Config, error) {
 			Endpoint:              viper.GetString("store.endpoint"),
 		},
 		Delegator: DelegatorServiceConfig{
-			KeyFile:               viper.GetString("delegator.key_file"),
-			IndexingServiceWebDID: viper.GetString("delegator.indexing_service_web_did"),
-			IndexingServiceProof:  viper.GetString("delegator.indexing_service_proof"),
-			UploadServiceDID:      viper.GetString("delegator.upload_service_did"),
+			KeyFile:                    viper.GetString("delegator.key_file"),
+			IndexingServiceWebDID:      viper.GetString("delegator.indexing_service_web_did"),
+			IndexingServiceProof:       viper.GetString("delegator.indexing_service_proof"),
+			EgressTrackingServiceDID:   viper.GetString("delegator.egress_tracking_service_did"),
+			EgressTrackingServiceProof: viper.GetString("delegator.egress_tracking_service_proof"),
+			UploadServiceDID:           viper.GetString("delegator.upload_service_did"),
 		},
 	}
 
@@ -52,6 +54,12 @@ func NewConfig() (*Config, error) {
 	}
 	if cfg.Delegator.IndexingServiceProof == "" {
 		return nil, fmt.Errorf("delegator indexing service proof not set")
+	}
+	if cfg.Delegator.EgressTrackingServiceDID == "" {
+		return nil, fmt.Errorf("delegator egress tracking service did not set")
+	}
+	if cfg.Delegator.EgressTrackingServiceProof == "" {
+		return nil, fmt.Errorf("delegator egress tracking service proof not set")
 	}
 	if cfg.Delegator.UploadServiceDID == "" {
 		return nil, fmt.Errorf("delegator upload did not set")
@@ -96,8 +104,10 @@ type DynamoConfig struct {
 }
 
 type DelegatorServiceConfig struct {
-	KeyFile               string `mapstructure:"key_file"`
-	IndexingServiceWebDID string `mapstructure:"indexing_service_web_did"`
-	IndexingServiceProof  string `mapstructure:"indexing_service_proof"`
-	UploadServiceDID      string `mapstructure:"upload_service_did"`
+	KeyFile                    string `mapstructure:"key_file"`
+	IndexingServiceWebDID      string `mapstructure:"indexing_service_web_did"`
+	IndexingServiceProof       string `mapstructure:"indexing_service_proof"`
+	EgressTrackingServiceDID   string `mapstructure:"egress_tracking_service_did"`
+	EgressTrackingServiceProof string `mapstructure:"egress_tracking_service_proof"`
+	UploadServiceDID           string `mapstructure:"upload_service_did"`
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -91,39 +91,8 @@ func (h *Handlers) Register(c echo.Context) error {
 	return c.NoContent(http.StatusCreated)
 }
 
-type RequestProofRequest struct {
-	DID string `json:"did"`
-}
-
-type RequestProofResponse struct {
-	Proof string `json:"proof"`
-}
-
 func (h *Handlers) RequestProof(c echo.Context) error {
-	var req RequestProofRequest
-	if err := c.Bind(&req); err != nil {
-		return c.String(http.StatusBadRequest, "invalid request body")
-	}
-
-	operator, err := did.Parse(req.DID)
-	if err != nil {
-		return c.String(http.StatusBadRequest, "invalid DID")
-	}
-
-	indexerProof, _, err := h.service.RequestProofs(c.Request().Context(), operator)
-	if err != nil {
-		// TODO map the errors the service returns to http codes
-		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
-	}
-
-	indexerProofStr, err := delegation.Format(indexerProof)
-	if err != nil {
-		return c.String(http.StatusInternalServerError, "failed to read generated indexer proof")
-	}
-
-	return c.JSON(http.StatusOK, RequestProofResponse{Proof: indexerProofStr})
+	return c.String(http.StatusGone, "this endpoint is deprecated, use /registrar/request-proofs instead")
 }
 
 type RequestProofsRequest struct {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -133,8 +133,45 @@ type IndexingServiceProofResult struct {
 func ProvideIndexingServiceProof(params IndexingServiceProofParams) (IndexingServiceProofResult, error) {
 	proof, err := delegation.Parse(params.Config.Delegator.IndexingServiceProof)
 	if err != nil {
-		return IndexingServiceProofResult{}, fmt.Errorf("failed to parse proof: %w", err)
+		return IndexingServiceProofResult{}, fmt.Errorf("failed to parse indexing service proof: %w", err)
 	}
 
 	return IndexingServiceProofResult{IndexingServiceProof: proof}, nil
+}
+
+type EgressTrackingServiceDIDParams struct {
+	fx.In
+	Config *config.Config
+}
+
+type EgressTrackingServiceDIDResult struct {
+	fx.Out
+	EgressTrackingServiceDID did.DID `name:"egress_tracking_service_did"`
+}
+
+func ProvideEgressTrackingServiceDID(params EgressTrackingServiceDIDParams) (EgressTrackingServiceDIDResult, error) {
+	parsedDID, err := did.Parse(params.Config.Delegator.EgressTrackingServiceDID)
+	if err != nil {
+		return EgressTrackingServiceDIDResult{}, fmt.Errorf("failed to parse egress tracking service DID: %w", err)
+	}
+
+	return EgressTrackingServiceDIDResult{EgressTrackingServiceDID: parsedDID}, nil
+}
+
+type EgressTrackingServiceProofParams struct {
+	fx.In
+	Config *config.Config
+}
+
+type EgressTrackingServiceProofResult struct {
+	fx.Out
+	EgressTrackingServiceProof delegation.Delegation `name:"egress_tracking_service_proof"`
+}
+
+func ProvideEgressTrackingServiceProof(params EgressTrackingServiceProofParams) (EgressTrackingServiceProofResult, error) {
+	proof, err := delegation.Parse(params.Config.Delegator.EgressTrackingServiceProof)
+	if err != nil {
+		return EgressTrackingServiceProofResult{}, fmt.Errorf("failed to parse egress tracking service proof: %w", err)
+	}
+	return EgressTrackingServiceProofResult{EgressTrackingServiceProof: proof}, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,7 +39,8 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/health", s.handlers.HealthCheck)
 	s.echo.GET("/", s.handlers.Root)
 	s.echo.PUT("/registrar/register-node", s.handlers.Register)
-	s.echo.GET("/registrar/request-proof", s.handlers.RequestProof)
+	s.echo.GET("/registrar/request-proof", s.handlers.RequestProof) // TODO: legacy, remove when nobody uses it
+	s.echo.GET("/registrar/request-proofs", s.handlers.RequestProofs)
 	s.echo.GET("/registrar/is-registered", s.handlers.IsRegistered)
 	s.echo.POST("/benchmark/upload", s.handlers.BenchmarkUpload)
 	s.echo.POST("/benchmark/download", s.handlers.BenchmarkDownload)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,7 +39,7 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/health", s.handlers.HealthCheck)
 	s.echo.GET("/", s.handlers.Root)
 	s.echo.PUT("/registrar/register-node", s.handlers.Register)
-	s.echo.GET("/registrar/request-proof", s.handlers.RequestProof) // TODO: legacy, remove when nobody uses it
+	s.echo.GET("/registrar/request-proof", s.handlers.RequestProof) // TODO: deprecated, remove when nobody uses it
 	s.echo.GET("/registrar/request-proofs", s.handlers.RequestProofs)
 	s.echo.GET("/registrar/is-registered", s.handlers.IsRegistered)
 	s.echo.POST("/benchmark/upload", s.handlers.BenchmarkUpload)


### PR DESCRIPTION
The delegator API already offers an endpoint to request a delegation that allows storage nodes to invoke `claim/cache` on the indexing service. This PR adds a new endpoint that returns, along with the delegation for the indexing service, a delegation that allows a storage node to invoke `space/egress/track` on the egress tracking service.

The original endpoint is preserved for backwards compatibility.