### PR TITLE
fix: contract transactor key is now an externally provisioned secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,6 @@ jobs:
       private-key: ${{ secrets.WARM_STAGING_PRIVATE_KEY }}
       indexing-service-proof: ${{ secrets.WARM_STAGING_INDEXING_SERVICE_PROOF }}
       egress-tracking-service-proof: ${{ secrets.WARM_STAGING_EGRESS_TRACKING_SERVICE_PROOF }}
-      contract-transactor-key: ${{ secrets.WARM_STAGING_CONTRACT_TRANSACTOR_KEY }}
       cloudflare-zone-id: ${{ secrets.WARM_STAGING_CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.WARM_STAGING_CLOUDFLARE_API_TOKEN }}
 
@@ -61,6 +60,5 @@ jobs:
       private-key: ${{ secrets.FORGE_PROD_PRIVATE_KEY }}
       indexing-service-proof: ${{ secrets.FORGE_PROD_INDEXING_SERVICE_PROOF }}
       egress-tracking-service-proof: ${{ secrets.FORGE_PROD_EGRESS_TRACKING_SERVICE_PROOF }}
-      contract-transactor-key: ${{ secrets.FORGE_PROD_CONTRACT_TRANSACTOR_KEY }}
       cloudflare-zone-id: ${{ secrets.FORGE_PROD_CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.FORGE_PROD_CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,8 +34,6 @@ on:
         required: true
       egress-tracking-service-proof:
         required: true
-      contract-transactor-key:
-        required: true
       cloudflare-zone-id:
         required: true
       cloudflare-api-token:
@@ -59,7 +57,6 @@ env:
   TF_VAR_region: ${{ secrets.region }}
   TF_VAR_indexing_service_proof: ${{ secrets.indexing-service-proof }}
   TF_VAR_egress_tracking_service_proof: ${{ secrets.egress-tracking-service-proof }}
-  TF_VAR_contract_transactor_key: ${{ secrets.contract-transactor-key }}
   TF_VAR_cloudflare_zone_id: ${{ secrets.cloudflare-zone-id }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare-api-token }}
   DEPLOY_ENV: ci

--- a/.storoku.json
+++ b/.storoku.json
@@ -14,15 +14,18 @@
   "secrets": [
     {
       "name": "REGISTRAR_DELEGATOR_INDEXING_SERVICE_PROOF",
-      "variable": true
+      "variable": true,
+      "external": false
     },
     {
       "name": "REGISTRAR_DELEGATOR_EGRESS_TRACKING_SERVICE_PROOF",
-      "variable": true
+      "variable": true,
+      "external": false
     },
     {
       "name": "REGISTRAR_CONTRACT_TRANSACTOR_KEY",
-      "variable": true
+      "variable": false,
+      "external": true
     }
   ],
   "tables": [

--- a/deploy/.env.terraform.tpl
+++ b/deploy/.env.terraform.tpl
@@ -7,6 +7,5 @@ TF_VAR_allowed_account_id=505595374361
 TF_VAR_region=us-east-2
 TF_VAR_indexing_service_proof= # enter a value for REGISTRAR_DELEGATOR_INDEXING_SERVICE_PROOF secret
 TF_VAR_egress_tracking_service_proof= # enter a value for REGISTRAR_DELEGATOR_EGRESS_TRACKING_SERVICE_PROOF secret
-TF_VAR_contract_transactor_key= # enter a value for REGISTRAR_CONTRACT_TRANSACTOR_KEY secret
 TF_VAR_cloudflare_zone_id= # enter the cloudflare zone id
 CLOUDFLARE_API_TOKEN= # enter a cloudflare api token

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -40,7 +40,7 @@ provider "aws" {
 
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.5.0"
+  source = "github.com/storacha/storoku//app?ref=v0.5.2"
   private_key = var.private_key
   private_key_env_var = "REGISTRAR_DELEGATOR_KEY"
   principal_mapping = var.principal_mapping
@@ -62,8 +62,9 @@ module "app" {
   secrets = { 
     "REGISTRAR_DELEGATOR_INDEXING_SERVICE_PROOF" = var.indexing_service_proof
     "REGISTRAR_DELEGATOR_EGRESS_TRACKING_SERVICE_PROOF" = var.egress_tracking_service_proof
-    "REGISTRAR_CONTRACT_TRANSACTOR_KEY" = var.contract_transactor_key
   }
+  # enter external secrets (provisioned out-of-band) here
+  external_secrets = ["REGISTRAR_CONTRACT_TRANSACTOR_KEY",]
   # enter any sqs queues you want to create here
   queues = []
   caches = []

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -60,8 +60,3 @@ variable "egress_tracking_service_proof" {
   description = "value for registrar_delegator_egress_tracking_service_proof secret"
   type = string
 }
-
-variable "contract_transactor_key" {
-  description = "value for registrar_contract_transactor_key secret"
-  type = string
-}

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -49,7 +49,7 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.5.0"
+  source = "github.com/storacha/storoku//shared?ref=v0.5.2"
   providers = {
     aws = aws
     aws.dev = aws.dev


### PR DESCRIPTION
Needs https://github.com/storacha/storoku/pull/31 to land first.

Use the support for externally provisioned secrets in storoku v0.5.2 to make the `CONTRACT_TRANSACTOR_KEY` secret external. It's value will be removed from the repo and we will be able to manage it directly in AWS Secrets Manager.

I confirmed this is working as expected in a test on `forge-prod`.