### PR TITLE
fix: upgrade to storoku v0.6.1 to get increased ALB timeout

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -76,9 +76,6 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/terraform-ci
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
         
       - uses: opentofu/setup-opentofu@v1
 
@@ -88,15 +85,22 @@ jobs:
           make init
         working-directory: deploy
 
-      - name: Build + Push Docker ECR
-        run: |
-          make docker-push
-        working-directory: deploy
-
+      # just plan if !inputs.apply
       - name: Terraform Plan
         if: ${{ !inputs.apply }}
         run: |
           make plan
+        working-directory: deploy
+
+      # build and push docker image and apply if inputs.apply
+      - name: Set up Docker Buildx
+        if: ${{ inputs.apply }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build + Push Docker ECR
+        if: ${{ inputs.apply }}
+        run: |
+          make docker-push
         working-directory: deploy
 
       - name: Terraform Apply

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.86.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source = "hashicorp/archive"
@@ -31,16 +31,10 @@ provider "aws" {
   }
 }
 
-# CloudFront is a global service. Certs must be created in us-east-1, where the core ACM infra lives
-provider "aws" {
-  region = "us-east-1"
-  alias = "acm"
-}
-
 
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.5.2"
+  source = "github.com/storacha/storoku//app?ref=v0.6.1"
   private_key = var.private_key
   private_key_env_var = "REGISTRAR_DELEGATOR_KEY"
   principal_mapping = var.principal_mapping
@@ -83,10 +77,6 @@ module "app" {
   ]
   buckets = [
   ]
-  providers = {
-    aws = aws
-    aws.acm = aws.acm
-  }
   env_files = var.env_files
   domain_base = var.domain_base
 }

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -49,7 +49,7 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.5.2"
+  source = "github.com/storacha/storoku//shared?ref=v0.6.1"
   providers = {
     aws = aws
     aws.dev = aws.dev


### PR DESCRIPTION
The v0.6.1 version of storoku changes the timeout in the ALB from 60 seconds to 600 seconds, which should be enough to solve timeouts when waiting for provider approval transactions to be completed.